### PR TITLE
fix #4: change output to nginx /var/www/site

### DIFF
--- a/scripts/vagrant-provision
+++ b/scripts/vagrant-provision
@@ -28,3 +28,6 @@ nginx -s reload
 
 # Add message for how to build the site
 echo 'It works!' > /var/www/site/index.html
+
+# Change ownership to vagrant
+chown -R vagrant:vagrant /var/www/site

--- a/site/build
+++ b/site/build
@@ -3,11 +3,10 @@
 set -e
 
 SITE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-OUTDIR=output
+OUTDIR=/var/www/site
 
-# Clear output directory
-rm -rf $OUTDIR
-mkdir -p $OUTDIR
+# Clear output directory contents
+rm -rf $OUTDIR/*
 
 # Install generator dependencies, if necessary
 if [ ! -d $SITE/generate/node_modules ]; then

--- a/site/generate/index.js
+++ b/site/generate/index.js
@@ -39,10 +39,6 @@ function main() {
   var siteDir = process.argv[2];
   var outDir = process.argv[3];
 
-  console.log('cleaning output directory');
-  rimraf.sync(outDir);
-  fs.mkdirSync(outDir);
-
   console.log('parsing language.json');
   var language =
     JSON.parse(fs.readFileSync(path.join(siteDir, 'data', 'language.json')));


### PR DESCRIPTION
The change to `scripts/vagrant-provision` was made so that `site/build` doesn't need to be run as root.
The change to `site/build` is the core fix to move the output to `/var/www/site`.
The change to `site/generate/index.js` removed to duplicate output directory clean.