### PR TITLE
continuing 87e7455ddf6f625885d173c1e97ad7d77a040a28: every property shou...

### DIFF
--- a/site/build/reference/render.js
+++ b/site/build/reference/render.js
@@ -55,11 +55,11 @@ function makeAvailability(value) {
   return availability;
 }
 
-function makeContribute(source, id) {
+function makeContribute(source) {
   var base =
     'https://github.com/briangreenery/relevance.io/tree/master/site/reference/';
 
-  return { source: base + source, id: id };
+  return base + source;
 }
 
 function renderProperty(property, template) {
@@ -116,7 +116,7 @@ function renderEntry(heading, body, property, source, template) {
     heading: heading,
     body: body,
     availability: makeAvailability(property),
-    contribute: makeContribute(source, escapeKey(property.key))
+    source: makeContribute(source)
   };
 
   if (property.pluralPhrase) {

--- a/site/templates/entry.html
+++ b/site/templates/entry.html
@@ -31,7 +31,7 @@
 
     <div class="links">
       <a href="#{{id}}">permalink</a>
-      {{#contribute}}<a href="{{source}}#{{id}}">edit</a>{{/contribute}}
+      <a href="{{source}}#{{id}}">edit</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
...ld have an edit

The original* pull request checked whether a source existed. We're not doing that check anymore, and every property should have a source (anyway). So, we should remove the conditional template.

*: https://github.com/briangreenery/relevance.io/pull/14/files